### PR TITLE
Favor newer math.fmod over math.mod

### DIFF
--- a/uuid.lua
+++ b/uuid.lua
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 local M = {}
 -----
 local function num2bs(num)
-	local _mod = math.mod
+	local _mod = math.fmod or math.mod
 	local _floor = math.floor
 	--
 	local index, result = 1 , ""


### PR DESCRIPTION
In Lua 5.1, math.mod was renamed to math.fmod. This change will favor
math.fmod over math.mod in the num2bs function, allowing it to work
under new Lua versions while maintaining backwards compatibility.
